### PR TITLE
Replace string literal usages in attribute examples with type-safe variants

### DIFF
--- a/source/attributes/drawer_attributes/animator_param.rst
+++ b/source/attributes/drawer_attributes/animator_param.rst
@@ -6,10 +6,10 @@ Select an Animator paramater via dropdown interface::
     {
         public Animator someAnimator;
 
-        [AnimatorParam(nameOf(someAnimator))]
+        [AnimatorParam(nameof(someAnimator))]
         public int paramHash;
 
-        [AnimatorParam(nameOf(someAnimator))]
+        [AnimatorParam(nameof(someAnimator))]
         public string paramName;
     }
 

--- a/source/attributes/drawer_attributes/animator_param.rst
+++ b/source/attributes/drawer_attributes/animator_param.rst
@@ -6,10 +6,10 @@ Select an Animator paramater via dropdown interface::
     {
         public Animator someAnimator;
 
-        [AnimatorParam("someAnimator")]
+        [AnimatorParam(nameOf(someAnimator))]
         public int paramHash;
 
-        [AnimatorParam("someAnimator")]
+        [AnimatorParam(nameOf(someAnimator))]
         public string paramName;
     }
 

--- a/source/attributes/drawer_attributes/dropdown.rst
+++ b/source/attributes/drawer_attributes/dropdown.rst
@@ -15,13 +15,13 @@ The values of the dropdown can be provided by a ``field``, ``property`` or ``fun
 
     public class NaughtyComponent : MonoBehaviour
     {
-        [Dropdown(nameOf(intValues))]
+        [Dropdown(nameof(intValues))]
         public int intValue;
 
-        [Dropdown(nameOf(StringValues))]
+        [Dropdown(nameof(StringValues))]
         public string stringValue;
 
-        [Dropdown(nameOf(GetVectorValues))]
+        [Dropdown(nameof(GetVectorValues))]
         public Vector3 vectorValue;
 
         private int[] intValues = new int[] { 1, 2, 3, 4, 5 };

--- a/source/attributes/drawer_attributes/dropdown.rst
+++ b/source/attributes/drawer_attributes/dropdown.rst
@@ -15,13 +15,13 @@ The values of the dropdown can be provided by a ``field``, ``property`` or ``fun
 
     public class NaughtyComponent : MonoBehaviour
     {
-        [Dropdown("intValues")]
+        [Dropdown(nameOf(intValues))]
         public int intValue;
 
-        [Dropdown("StringValues")]
+        [Dropdown(nameOf(StringValues))]
         public string stringValue;
 
-        [Dropdown("GetVectorValues")]
+        [Dropdown(nameOf(GetVectorValues))]
         public Vector3 vectorValue;
 
         private int[] intValues = new int[] { 1, 2, 3, 4, 5 };

--- a/source/attributes/meta_attributes/enable_disable_if.rst
+++ b/source/attributes/meta_attributes/enable_disable_if.rst
@@ -15,13 +15,13 @@ The condition can be a ``field``, ``property`` or ``function``.
     {
         public bool enableMyInt;
 
-        [EnableIf(nameOf(enableMyInt))]
+        [EnableIf(nameof(enableMyInt))]
         public int myInt;
 
-        [EnableIf(nameOf(Enabled))]
+        [EnableIf(nameof(Enabled))]
         public float myFloat;
 
-        [EnableIf(nameOf(NotEnabled))]
+        [EnableIf(nameof(NotEnabled))]
         public Vector3 myVector;
 
         public bool Enabled() { return true; }
@@ -38,10 +38,10 @@ You can have more than one condition::
         public bool flag0;
         public bool flag1;
 
-        [EnableIf(EConditionOperator.And, nameOf(flag0), nameOf(flag1))]
+        [EnableIf(EConditionOperator.And, nameof(flag0), nameof(flag1))]
         public int enabledIfAll;
 
-        [EnableIf(EConditionOperator.Or, nameOf(flag0), nameOf(flag1))]
+        [EnableIf(EConditionOperator.Or, nameof(flag0), nameof(flag1))]
         public int enabledIfAny;
     }
 
@@ -51,7 +51,7 @@ An enum value can also be used as a condition::
     {
         public EMyEnum enumFlag;
 
-        [EnableIf(nameOf(enumFlag), EMyEnum.Case0)]
+        [EnableIf(nameof(enumFlag), EMyEnum.Case0)]
         public int enableIfEnum; // Will be enabled only if enumFlag == EMyEnum.Case0
     }
 

--- a/source/attributes/meta_attributes/enable_disable_if.rst
+++ b/source/attributes/meta_attributes/enable_disable_if.rst
@@ -15,13 +15,13 @@ The condition can be a ``field``, ``property`` or ``function``.
     {
         public bool enableMyInt;
 
-        [EnableIf("enableMyInt")]
+        [EnableIf(nameOf(enableMyInt))]
         public int myInt;
 
-        [EnableIf("Enabled")]
+        [EnableIf(nameOf(Enabled))]
         public float myFloat;
 
-        [EnableIf("NotEnabled")]
+        [EnableIf(nameOf(NotEnabled))]
         public Vector3 myVector;
 
         public bool Enabled() { return true; }
@@ -38,10 +38,10 @@ You can have more than one condition::
         public bool flag0;
         public bool flag1;
 
-        [EnableIf(EConditionOperator.And, "flag0", "flag1")]
+        [EnableIf(EConditionOperator.And, nameOf(flag0), nameOf(flag1))]
         public int enabledIfAll;
 
-        [EnableIf(EConditionOperator.Or, "flag0", "flag1")]
+        [EnableIf(EConditionOperator.Or, nameOf(flag0), nameOf(flag1))]
         public int enabledIfAny;
     }
 
@@ -51,7 +51,7 @@ An enum value can also be used as a condition::
     {
         public EMyEnum enumFlag;
 
-        [EnableIf("enumFlag", EMyEnum.Case0)]
+        [EnableIf(nameOf(enumFlag), EMyEnum.Case0)]
         public int enableIfEnum; // Will be enabled only if enumFlag == EMyEnum.Case0
     }
 

--- a/source/attributes/meta_attributes/on_value_changed.rst
+++ b/source/attributes/meta_attributes/on_value_changed.rst
@@ -12,7 +12,7 @@ If you want a runtime event, you should probably use an event/delegate and subsc
 
     public class NaughtyComponent : MonoBehaviour
     {
-        [OnValueChanged("OnValueChangedCallback")]
+        [OnValueChanged(nameOf(OnValueChangedCallback))]
         public int myInt;
 
         private void OnValueChangedCallback()

--- a/source/attributes/meta_attributes/on_value_changed.rst
+++ b/source/attributes/meta_attributes/on_value_changed.rst
@@ -12,7 +12,7 @@ If you want a runtime event, you should probably use an event/delegate and subsc
 
     public class NaughtyComponent : MonoBehaviour
     {
-        [OnValueChanged(nameOf(OnValueChangedCallback))]
+        [OnValueChanged(nameof(OnValueChangedCallback))]
         public int myInt;
 
         private void OnValueChangedCallback()

--- a/source/attributes/meta_attributes/show_hide_if.rst
+++ b/source/attributes/meta_attributes/show_hide_if.rst
@@ -13,13 +13,13 @@ The condition can be a ``field``, ``property`` or ``function``.
     {
         public bool showInt;
 
-        [ShowIf("showInt")]
+        [ShowIf(nameOf(showInt))]
         public int myInt;
 
-        [ShowIf("AlwaysShow")]
+        [ShowIf(nameOf(AlwaysShow))]
         public float myFloat;
 
-        [ShowIf("NeverShow")]
+        [ShowIf(nameOf(NeverShow))]
         public Vector3 myVector;
 
         public bool AlwaysShow() { return true; }
@@ -36,10 +36,10 @@ You can have more than one condition::
         public bool flag0;
         public bool flag1;
 
-        [ShowIf(EConditionOperator.And, "flag0", "flag1")]
+        [ShowIf(EConditionOperator.And, nameOf(flag0), nameOf(flag1))]
         public int showIfAll;
 
-        [ShowIf(EConditionOperator.Or, "flag0", "flag1")]
+        [ShowIf(EConditionOperator.Or, nameOf(flag0), nameOf(flag1))]
         public int showIfAny;
     }
 
@@ -49,7 +49,7 @@ An enum value can also be used as a condition::
     {
         public EMyEnum enumFlag;
 
-        [ShowIf("enumFlag", EMyEnum.Case0)]
+        [ShowIf(nameOf(enumFlag), EMyEnum.Case0)]
         public int enableIfEnum; // Will be shown only if enumFlag == EMyEnum.Case0
     }
 

--- a/source/attributes/meta_attributes/show_hide_if.rst
+++ b/source/attributes/meta_attributes/show_hide_if.rst
@@ -13,13 +13,13 @@ The condition can be a ``field``, ``property`` or ``function``.
     {
         public bool showInt;
 
-        [ShowIf(nameOf(showInt))]
+        [ShowIf(nameof(showInt))]
         public int myInt;
 
-        [ShowIf(nameOf(AlwaysShow))]
+        [ShowIf(nameof(AlwaysShow))]
         public float myFloat;
 
-        [ShowIf(nameOf(NeverShow))]
+        [ShowIf(nameof(NeverShow))]
         public Vector3 myVector;
 
         public bool AlwaysShow() { return true; }
@@ -36,10 +36,10 @@ You can have more than one condition::
         public bool flag0;
         public bool flag1;
 
-        [ShowIf(EConditionOperator.And, nameOf(flag0), nameOf(flag1))]
+        [ShowIf(EConditionOperator.And, nameof(flag0), nameof(flag1))]
         public int showIfAll;
 
-        [ShowIf(EConditionOperator.Or, nameOf(flag0), nameOf(flag1))]
+        [ShowIf(EConditionOperator.Or, nameof(flag0), nameof(flag1))]
         public int showIfAny;
     }
 
@@ -49,7 +49,7 @@ An enum value can also be used as a condition::
     {
         public EMyEnum enumFlag;
 
-        [ShowIf(nameOf(enumFlag), EMyEnum.Case0)]
+        [ShowIf(nameof(enumFlag), EMyEnum.Case0)]
         public int enableIfEnum; // Will be shown only if enumFlag == EMyEnum.Case0
     }
 

--- a/source/attributes/special_attributes/allow_nesting.rst
+++ b/source/attributes/special_attributes/allow_nesting.rst
@@ -17,7 +17,7 @@ If you want to use :ref:`label-enable-disable-if` attributes inside structs for 
     {
         public bool enableFlag;
 
-        [EnableIf(nameOf(enableFlag))]
+        [EnableIf(nameof(enableFlag))]
         [AllowNesting] // Because it's nested we need to explicitly allow nesting
         public int integer;
     }

--- a/source/attributes/special_attributes/allow_nesting.rst
+++ b/source/attributes/special_attributes/allow_nesting.rst
@@ -17,7 +17,7 @@ If you want to use :ref:`label-enable-disable-if` attributes inside structs for 
     {
         public bool enableFlag;
 
-        [EnableIf("enableFlag")]
+        [EnableIf(nameOf(enableFlag))]
         [AllowNesting] // Because it's nested we need to explicitly allow nesting
         public int integer;
     }

--- a/source/attributes/validator_attributes/validate_input.rst
+++ b/source/attributes/validator_attributes/validate_input.rst
@@ -10,10 +10,10 @@ The most powerful ValidatorAttribute.
 
     public class NaughtyComponent : MonoBehaviour
     {
-        [ValidateInput("IsNotNull")]
+        [ValidateInput(nameOf(IsNotNull))]
         public Transform myTransform;
 
-        [ValidateInput("IsGreaterThanZero", "myInteger must be greater than zero")]
+        [ValidateInput(nameOf(IsGreaterThanZero), "myInteger must be greater than zero")]
         public int myInt;
 
         private bool IsNotNull(Transform tr)

--- a/source/attributes/validator_attributes/validate_input.rst
+++ b/source/attributes/validator_attributes/validate_input.rst
@@ -10,10 +10,10 @@ The most powerful ValidatorAttribute.
 
     public class NaughtyComponent : MonoBehaviour
     {
-        [ValidateInput(nameOf(IsNotNull))]
+        [ValidateInput(nameof(IsNotNull))]
         public Transform myTransform;
 
-        [ValidateInput(nameOf(IsGreaterThanZero), "myInteger must be greater than zero")]
+        [ValidateInput(nameof(IsGreaterThanZero), "myInteger must be greater than zero")]
         public int myInt;
 
         private bool IsNotNull(Transform tr)


### PR DESCRIPTION
This would change something like
```cs
public Animator someAnimator;

[AnimatorParam("someAnimator")]
public int paramHash;
```
with
```cs
public Animator someAnimator;

[AnimatorParam(nameof(someAnimator))]
public int paramHash;
```